### PR TITLE
Added callback when video play is finished

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ omx.express = function(req,res,next) {
     next();
 };
 
-omx.start = function(fn) {
+omx.start = function(fn, onFinish) {
     if (!pipe) {
         pipe = 'omxcontrol';
         exec('mkfifo '+pipe);
@@ -50,6 +50,9 @@ omx.start = function(fn) {
         console.log(fn);
         exec('omxplayer -o hdmi "'+fn+'" < '+pipe,function(error, stdout, stderr) {
             console.log(stdout);
+            if (onFinish) {
+                onFinish();
+            }
         });
         exec('echo . > '+pipe);
     }


### PR DESCRIPTION
This callback can be used for notifying frontend that currently played video is finished. I use it to change "play" button to "stop" button.

It can be used this way:

```
omx.start(id + '.mp4', function () {
    socket.emit("finish");
}); 
```
